### PR TITLE
Be more careful before invoking resolveType()

### DIFF
--- a/dist/resolve-unions.js
+++ b/dist/resolve-unions.js
@@ -66,9 +66,9 @@ const disambiguateQualifiedTypeFields = (obj, childASTsql, typeName, qualifiedNa
   const resolveTypeFn = typeof resolveType === 'function' && resolveType.length < 2 ? resolveType : null;
   const resolveTypeResult = resolveTypeFn ? resolveTypeFn(obj) : null;
   const discriminatorTypeName = typeof resolveTypeResult === 'string' ? resolveTypeResult : null;
-  const fieldTypeMatchesResolvedType = discriminatorTypeName && typeName === discriminatorTypeName;
+  const fieldTypeMatchesResolvedType = typeName === discriminatorTypeName;
 
-  if (!fieldTypeMatchesResolvedType) {
+  if (discriminatorTypeName && !fieldTypeMatchesResolvedType) {
     return;
   }
 

--- a/dist/resolve-unions.js
+++ b/dist/resolve-unions.js
@@ -59,18 +59,22 @@ function resolveUnions(data, sqlAST) {
   }
 }
 
-const disambiguateQualifiedTypeFields = (data, childASTsql, typeName, qualifiedName, requestedFieldName) => {
-  const discriminatorTypeName = childASTsql.defferedFrom?.resolveType ? childASTsql.defferedFrom.resolveType(data) : null;
-  const qualifiedValue = data[qualifiedName];
-  delete data[qualifiedName];
+const disambiguateQualifiedTypeFields = (obj, childASTsql, typeName, qualifiedName, requestedFieldName) => {
+  const qualifiedValue = obj[qualifiedName];
+  delete obj[qualifiedName];
+  const resolveType = childASTsql.defferedFrom?.resolveType;
+  const resolveTypeFn = typeof resolveType === 'function' && resolveType.length < 2 ? resolveType : null;
+  const resolveTypeResult = resolveTypeFn ? resolveTypeFn(obj) : null;
+  const discriminatorTypeName = typeof resolveTypeResult === 'string' ? resolveTypeResult : null;
+  const fieldTypeMatchesResolvedType = discriminatorTypeName && typeName === discriminatorTypeName;
 
-  if (discriminatorTypeName && typeName !== discriminatorTypeName) {
+  if (!fieldTypeMatchesResolvedType) {
     return;
   }
 
-  if (data[requestedFieldName] == null && qualifiedValue != null) {
-    data[requestedFieldName] = qualifiedValue;
-  } else if ((0, _util.isEmptyArray)(data[requestedFieldName]) && !(0, _util.isEmptyArray)(qualifiedValue)) {
-    data[requestedFieldName] = qualifiedValue;
+  if (obj[requestedFieldName] == null && qualifiedValue != null) {
+    obj[requestedFieldName] = qualifiedValue;
+  } else if ((0, _util.isEmptyArray)(obj[requestedFieldName]) && !(0, _util.isEmptyArray)(qualifiedValue)) {
+    obj[requestedFieldName] = qualifiedValue;
   }
 };

--- a/src/resolve-unions.js
+++ b/src/resolve-unions.js
@@ -119,9 +119,9 @@ const disambiguateQualifiedTypeFields = (obj, childASTsql, typeName, qualifiedNa
   const resolveTypeResult = resolveTypeFn ? resolveTypeFn(obj) : null
   const discriminatorTypeName = typeof resolveTypeResult === 'string' ? resolveTypeResult : null
 
-  const fieldTypeMatchesResolvedType = discriminatorTypeName && typeName === discriminatorTypeName
+  const fieldTypeMatchesResolvedType = typeName === discriminatorTypeName
 
-  if (!fieldTypeMatchesResolvedType) {
+  if (discriminatorTypeName && !fieldTypeMatchesResolvedType) {
     // Remove the field@TypeName from obj without replacing it
     return
   }

--- a/src/resolve-unions.js
+++ b/src/resolve-unions.js
@@ -2,7 +2,7 @@ import { chain } from 'lodash'
 import { isEmptyArray } from './util'
 
 // union types have additional processing. the field names have a @ and the typename appended to them.
-// need to strip those off and take whichever of those values are non-null
+// need to strip those off and take whichever of those values match the type discriminator specified in resolveType
 export default function resolveUnions(data, sqlAST) {
   if (!data || (Array.isArray(data) && data.length === 0)) {
     return
@@ -15,16 +15,18 @@ export default function resolveUnions(data, sqlAST) {
       for (let child of children) {
         const fieldName = child.fieldName
         const qualifiedName = child.fieldName + suffix
+
         if (Array.isArray(data)) {
           for (let obj of data) {
             disambiguateQualifiedTypeFields(obj, child, typeName, qualifiedName, fieldName)
           }
+
           if (child.type === 'table' || child.type === 'union') {
             const nextLevelData = chain(data)
-              .filter(obj => obj != null)
-              .flatMap(obj => obj[fieldName])
-              .filter(obj => obj != null)
-              .value()
+                .filter(obj => obj != null)
+                .flatMap(obj => obj[fieldName])
+                .filter(obj => obj != null)
+                .value()
             resolveUnions(nextLevelData, child)
           }
         } else {
@@ -40,16 +42,16 @@ export default function resolveUnions(data, sqlAST) {
   if (sqlAST.type === 'table' || sqlAST.type === 'union') {
     for (let child of sqlAST.children) {
       if (
-        (child.type === 'table' || child.type === 'union') &&
-        !child.sqlBatch
+          (child.type === 'table' || child.type === 'union') &&
+          !child.sqlBatch
       ) {
         const fieldName = child.fieldName
         if (Array.isArray(data)) {
           const nextLevelData = chain(data)
-            .filter(obj => obj != null)
-            .flatMap(obj => obj[fieldName])
-            .filter(obj => obj != null)
-            .value()
+              .filter(obj => obj != null)
+              .flatMap(obj => obj[fieldName])
+              .filter(obj => obj != null)
+              .value()
           resolveUnions(nextLevelData, child)
         } else {
           resolveUnions(data[fieldName], child)
@@ -99,29 +101,37 @@ export default function resolveUnions(data, sqlAST) {
  *
  *   Where it is not possible to use resolveType() to choose, the first-encountered key will be used as the field.
  *
+ *   The resolveType function must be a function that takes 0 or 1 arguments and returns a string. It cannot accept the
+ *   context or info objects, or return a Promise.
  *
- * @param data
+ * @param obj
  * @param childASTsql
  * @param typeName
  * @param qualifiedName
  * @param requestedFieldName
  */
-const disambiguateQualifiedTypeFields = (data, childASTsql, typeName, qualifiedName, requestedFieldName) => {
-  const discriminatorTypeName = childASTsql.defferedFrom?.resolveType ? childASTsql.defferedFrom.resolveType(data) : null
-  const qualifiedValue = data[qualifiedName]
+const disambiguateQualifiedTypeFields = (obj, childASTsql, typeName, qualifiedName, requestedFieldName) => {
+  const qualifiedValue = obj[qualifiedName]
+  delete obj[qualifiedName]
 
-  delete data[qualifiedName]
+  const resolveType = childASTsql.defferedFrom?.resolveType
+  const resolveTypeFn = typeof resolveType === 'function' && resolveType.length < 2 ? resolveType : null
+  const resolveTypeResult = resolveTypeFn ? resolveTypeFn(obj) : null
+  const discriminatorTypeName = typeof resolveTypeResult === 'string' ? resolveTypeResult : null
 
-  if (discriminatorTypeName && typeName !== discriminatorTypeName) {
+  const fieldTypeMatchesResolvedType = discriminatorTypeName && typeName === discriminatorTypeName
+
+  if (!fieldTypeMatchesResolvedType) {
+    // Remove the field@TypeName from obj without replacing it
     return
   }
 
-  if (data[requestedFieldName] == null && qualifiedValue != null) {
-    data[requestedFieldName] = qualifiedValue
+  if (obj[requestedFieldName] == null && qualifiedValue != null) {
+    obj[requestedFieldName] = qualifiedValue
   } else if (
-      isEmptyArray(data[requestedFieldName]) &&
+      isEmptyArray(obj[requestedFieldName]) &&
       !isEmptyArray(qualifiedValue)
   ) {
-    data[requestedFieldName] = qualifiedValue
+    obj[requestedFieldName] = qualifiedValue
   }
 }


### PR DESCRIPTION
Follow up to: https://github.com/vendrinc/join-monster/pull/6 after finding resolveType is not always safe to call. 

- make the assumption that resolveType can only be used if set up to derive the type only from the resolved value, synchronously
 - check that it's a function that only accepts the value argument of resolveType
 - we do not have the context or info object from the request anywhere nearby to be able to invoke resolveType correctly (see https://github.com/graphql/graphql-js/blob/9c90a23dd430ba7b9db3d566b084e9f66aded346/src/type/definition.ts#L863)
 - if any of the assumptions do not hold, fall back to old behaviour of taking first matching data
