### PR TITLE
fix exception matching to cope with version differences

### DIFF
--- a/dist/stringifiers/shared.js
+++ b/dist/stringifiers/shared.js
@@ -247,7 +247,7 @@ function isVendrCursor(cursor) {
 
     return false;
   } catch (error) {
-    if (String(error).match(/Unexpected token.* in JSON at position/)) {
+    if (error instanceof SyntaxError) {
       return false;
     }
 

--- a/src/stringifiers/shared.js
+++ b/src/stringifiers/shared.js
@@ -242,7 +242,7 @@ function isVendrCursor(cursor) {
 
     return false
   } catch (error) {
-    if (String(error).match(/Unexpected token.* in JSON at position/)) {
+    if (error instanceof SyntaxError) {
       return false
     }
 


### PR DESCRIPTION
Different version of Node may have different error messages, e.g:
- node 16: 'Unexpected token a in JSON at position 0'
- node 20: 'Unexpected token 'a', "arrayconnection:9" is not valid JSON'

